### PR TITLE
Allow self signed certificate ignoring ssl checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -525,6 +525,9 @@ Other options that can be passed to Selenium Wire via the ``seleniumwire_options
 ``disable_encoding``
     Whether to disable content encoding. When set to ``True``, the ``Accept-Encoding`` header will be set to ``identity`` for all requests. This tells the server to not compress/modify the response. Default is ``False``.
 
+``ssl_verify``
+    If it's `False` ignore the certificate check on request.  Allow self signed certificate on development servers. 
+
 Limitations
 ~~~~~~~~~~~
 

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -123,6 +123,7 @@ class CaptureRequestHandler(AdminMixin, ProxyRequestHandler):
     """
 
     def do_GET(self):
+        self.check_ssl = self.server.options.get('ssl_verify', True)
         try:
             super().do_GET()
         except (socket.timeout, BrokenPipeError) as e:


### PR DESCRIPTION
This PR, allow to ignore ssl check on proxy server, so self signed certificates can handle on proxy.

Use example 

```
   driver = webdriver.Chrome('chromedriver',
                              seleniumwire_options={'ssl_verify': False})
```