### PR TITLE
Support configurations of the request storage base directory

### DIFF
--- a/seleniumwire/proxy/server.py
+++ b/seleniumwire/proxy/server.py
@@ -12,7 +12,9 @@ class ProxyHTTPServer(ThreadingHTTPServer):
 
     def __init__(self, *args, proxy_config=None, options=None, **kwargs):
         # Each server instance gets its own storage
-        self.storage = RequestStorage()
+        self.storage = RequestStorage(
+            base_dir=proxy_config.pop('request_storage_base_dir', None)
+        )
 
         # Each server instance gets a request modifier
         self.modifier = RequestModifier()

--- a/seleniumwire/proxy/server.py
+++ b/seleniumwire/proxy/server.py
@@ -13,7 +13,7 @@ class ProxyHTTPServer(ThreadingHTTPServer):
     def __init__(self, *args, proxy_config=None, options=None, **kwargs):
         # Each server instance gets its own storage
         self.storage = RequestStorage(
-            base_dir=proxy_config.pop('request_storage_base_dir', None)
+            base_dir=options.pop('request_storage_base_dir', None)
         )
 
         # Each server instance gets a request modifier


### PR DESCRIPTION
I tried this package with proxies in AWS Lambda, and got an error,
caused by the read only permission with the user home directory in the Lambda environment.

Here is a part of the stack trace.

```
File "/opt/python/seleniumwire/proxy/server.py", line 15, in __init__
self.storage = RequestStorage()
File "/opt/python/seleniumwire/proxy/storage.py", line 38, in __init__
os.makedirs(self._storage_dir)
File "/var/lang/lib/python3.6/os.py", line 210, in makedirs
makedirs(head, mode, exist_ok)
File "/var/lang/lib/python3.6/os.py", line 210, in makedirs
makedirs(head, mode, exist_ok)
File "/var/lang/lib/python3.6/os.py", line 220, in makedirs
mkdir(name, mode)
OSError: [Errno 30] Read-only file system: '/home/sbx_user1051'
```

Now this should work perfectly fine for Lambda.

```
options = {
    'proxy': {
        'http': 'http://username:password@host:port',
        'https': 'https://username:password@host:port',
        'no_proxy': 'localhost,127.0.0.1,dev_server:8080',
        'request_storage_base_dir': '/tmp'
    }
}
driver = webdriver.Firefox(seleniumwire_options=options)
```