### PR TITLE
allow `about:` scheme when proxying request

### DIFF
--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -79,7 +79,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
 
         u = urllib.parse.urlsplit(req.path)
         scheme, netloc, path = u.scheme, u.netloc, (u.path + '?' + u.query if u.query else u.path)
-        assert scheme in ('http', 'https')
+        assert scheme in ('http', 'https', 'about')
         if netloc:
             req.headers['Host'] = netloc
         setattr(req, 'headers', self._filter_headers(req.headers))


### PR DESCRIPTION
The website I'm testing makes a lot of requests to third-party services, which make the tests slow. I'd like to be able to block them by rewriting them to `about:blank`: 

```
driver.rewrite_rules = [
        (r'(https?://)(.*)facebook(.*)', r'about:blank'),
        (r'(https?://)(.*)googleapis(.*)', r'about:blank'),
        (r'(https?://)(.*)contentsquare(.*)', r'about:blank'),
        (r'(https?://)(.*)appdynamics(.*)', r'about:blank'),
        (r'(https?://)(.*)gstatic(.*)', r'about:blank'),
        (r'(https?://)(.*)twitter(.*)', r'about:blank'),
        (r'(https?://)(.*)pinterest(.*)', r'about:blank'),
        (r'(https?://)(.*)bing(.*)', r'about:blank'),
        (r'(https?://)(.*)google-analytics(.*)', r'about:blank'),
        (r'(https?://)(.*)doubleclick(.*)', r'about:blank'),
        (r'(https?://)(.*)fontawesome(.*)', r'about:blank'),
        (r'(https?://)(.*)googletagmanager(.*)', r'about:blank'),
        (r'(https?://)(.*)myfonts(.*)', r'about:blank'),
    ]
```

However that results in an `AssertionError` (the scheme must be HTTP or HTTPS): 
```
Exception happened during processing of request from ('127.0.0.1', 63098)
Traceback (most recent call last):
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/site-packages/seleniumwire/proxy/handler.py", line 164, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/site-packages/seleniumwire/proxy/proxy2.py", line 47, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/http/server.py", line 428, in handle
    self.handle_one_request()
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/Users/kevin/.pyenv/versions/3.7.2/lib/python3.7/site-packages/seleniumwire/proxy/proxy2.py", line 99, in do_GET
    assert scheme in ('http', 'https')
AssertionError
```

Allowing `about` as a scheme allows this blocking technique to work and makes the tests run a lot faster. 

Or is there a better way to block these third-party script requests?