### PR TITLE
Update client.py

### DIFF
--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -256,7 +256,6 @@ class AdminClient:
                     data = json.loads(data.decode(encoding='utf-8'))
             except (UnicodeDecodeError, ValueError):
                 pass
-            return data
         except ProxyException:
             raise
         except Exception as e:
@@ -266,6 +265,7 @@ class AdminClient:
                 conn.close()
             except ConnectionError:
                 pass
+        return data
 
 
 class ProxyException(Exception):


### PR DESCRIPTION
The connection not being closed due to the data being returned in _make_request method causes errors 10048 & 10064(?) on Windows due to the port remaining connected to the previous call to the proxy address but never being closed prior to returning data.