### PR TITLE
WIP: Access Websocket Messages

### DIFF
--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -259,7 +259,6 @@ class AdminClient:
         except ProxyException:
             raise
         except Exception as e:
-            import pdb;pdb.set_trace()
             raise ProxyException('Unable to retrieve data from proxy: {}'.format(e))
         finally:
             try:

--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -258,7 +258,7 @@ class AdminClient:
                 pass
         except ProxyException:
             raise
-        except TypeError as e:
+        except Exception as e:
             raise ProxyException('Unable to retrieve data from proxy: {}'.format(e))
         finally:
             try:

--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -258,7 +258,7 @@ class AdminClient:
                 pass
         except ProxyException:
             raise
-        except Exception as e:
+        except TypeError as e:
             raise ProxyException('Unable to retrieve data from proxy: {}'.format(e))
         finally:
             try:

--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -259,6 +259,7 @@ class AdminClient:
         except ProxyException:
             raise
         except Exception as e:
+            import pdb;pdb.set_trace()
             raise ProxyException('Unable to retrieve data from proxy: {}'.format(e))
         finally:
             try:

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -301,6 +301,7 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
             res: The response (a http.client.HTTPResponse instance) that corresponds to the request.
             res_body: The binary response body.
         """
+        print('here')
         if messages is list:
             print('handler.handle_response', id(messages))
         if not hasattr(req, 'id'):

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -301,9 +301,6 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
             res: The response (a http.client.HTTPResponse instance) that corresponds to the request.
             res_body: The binary response body.
         """
-        print('here')
-        if messages is list:
-            print('handler.handle_response', id(messages))
         if not hasattr(req, 'id'):
             # Request was not stored
             return

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -292,7 +292,7 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
 
         return req_body
 
-    def handle_response(self, req, req_body, res, res_body):
+    def handle_response(self, req, req_body, res, res_body, messages=None):
         """Captures a response and its body that relate to a previous request.
 
         Args:
@@ -314,7 +314,8 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
             status_code=res.status,
             reason=res.reason,
             headers=dict(res.headers),
-            body=res_body
+            body=res_body,
+            messages,
         )
 
         self.capture_response(req.id, req.path, response)

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -315,7 +315,7 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
             reason=res.reason,
             headers=dict(res.headers),
             body=res_body,
-            messages,
+            messages=messages,
         )
 
         self.capture_response(req.id, req.path, response)

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -301,6 +301,8 @@ class CaptureRequestHandler(CaptureMixin, AdminMixin, ProxyRequestHandler):
             res: The response (a http.client.HTTPResponse instance) that corresponds to the request.
             res_body: The binary response body.
         """
+        if messages is list:
+            print('handler.handle_response', id(messages))
         if not hasattr(req, 'id'):
             # Request was not stored
             return

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -86,12 +86,9 @@ class AdminMixin:
         return func(request, **params)
 
     def _get_requests(self, _):
-        try:
-            return self._create_response(json.dumps(
-                [r.to_dict() for r in self.storage.load_requests()]
-            ).encode('utf-8'))
-        except:
-            import pdb;pdb.set_trace()
+        return self._create_response(json.dumps(
+            [r.to_dict() for r in self.storage.load_requests()]
+        ).encode('utf-8'))
 
     def _get_last_request(self, _):
         request = self.storage.load_last_request()

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -86,9 +86,12 @@ class AdminMixin:
         return func(request, **params)
 
     def _get_requests(self, _):
-        return self._create_response(json.dumps(
-            [r.to_dict() for r in self.storage.load_requests()]
-        ).encode('utf-8'))
+        try:
+            return self._create_response(json.dumps(
+                [r.to_dict() for r in self.storage.load_requests()]
+            ).encode('utf-8'))
+        except:
+            import pdb;pdb.set_trace()
 
     def _get_last_request(self, _):
         request = self.storage.load_last_request()

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -218,6 +218,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     serverdata = server_sock.recv(4096)
                     if not serverdata:
                         break
+                    print('appending', serverdata, id(messages))
                     messages.append(serverdata)
                     self.connection.sendall(serverdata)
             except socket.error:
@@ -227,6 +228,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     server_sock.close()
                 if self.connection:
                     self.connection.close()
+            print('done', id(messages))
 
         t = threading.Thread(target=server_read, args=(messages,), daemon=True)
         t.start()

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -125,16 +125,17 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             self.send_header(header, val)
         self.end_headers()
 
-        if res_body:
-            self.wfile.write(res_body)
-
-        self.wfile.flush()
-
         if self.websocket:
             self._handle_websocket(conn.sock, ws_messages)
             self.close_connection = True
         elif not self._keepalive():
             self.close_connection = True
+
+        if res_body:
+            self.wfile.write(res_body)
+
+        self.wfile.flush()
+
 
     def _create_connection(self, origin):
         scheme, netloc = origin

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -126,8 +126,6 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         if res_body:
-            if self.websocket:
-                import pdb;pdb.set_trace()
             self.wfile.write(res_body)
 
         self.wfile.flush()

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -129,7 +129,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
         self.wfile.flush()
 
         if self.websocket:
-            self._handle_websocket(conn.sock, ws_messages)
+            self._handle_websocket(conn.sock, messages)
             self.close_connection = True
         elif not self._keepalive():
             self.close_connection = True

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -227,7 +227,6 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     server_sock.close()
                 if self.connection:
                     self.connection.close()
-            print('done', id(messages))
 
         t = threading.Thread(target=server_read, args=(messages,), daemon=True)
         t.start()

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -225,7 +225,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     self.connection.close()
 
         response.messages = []
-        t = threading.Thread(target=server_read, args=(response.messages), daemon=True)
+        t = threading.Thread(target=server_read, args=(response.messages,), daemon=True)
         t.start()
 
         try:

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -126,6 +126,8 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         if res_body:
+            if self.websocket:
+                import pdb;pdb.set_trace()
             self.wfile.write(res_body)
 
         self.wfile.flush()

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -125,17 +125,16 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             self.send_header(header, val)
         self.end_headers()
 
-        if self.websocket:
-            self._handle_websocket(conn.sock, ws_messages)
-            self.close_connection = True
-        elif not self._keepalive():
-            self.close_connection = True
-
         if res_body:
             self.wfile.write(res_body)
 
         self.wfile.flush()
 
+        if self.websocket:
+            self._handle_websocket(conn.sock, ws_messages)
+            self.close_connection = True
+        elif not self._keepalive():
+            self.close_connection = True
 
     def _create_connection(self, origin):
         scheme, netloc = origin

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -94,7 +94,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             if res.headers.get('Upgrade') == 'websocket':
                 self.websocket = True
                 messages = []
-                setattr(res, 'ws_messages', messages)
+                setattr(res, 'messages', messages)
 
             version_table = {10: 'HTTP/1.0', 11: 'HTTP/1.1'}
             setattr(res, 'headers', res.msg)

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -225,7 +225,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     self.connection.close()
 
         response.messages = []
-        t = threading.Thread(target=server_read, args=(response.messages) daemon=True)
+        t = threading.Thread(target=server_read, args=(response.messages), daemon=True)
         t.start()
 
         try:

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -220,7 +220,6 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     serverdata = server_sock.recv(4096)
                     if not serverdata:
                         break
-                    print('appending', serverdata, id(messages))
                     messages.append(serverdata)
                     self.connection.sendall(serverdata)
             except socket.error:

--- a/seleniumwire/proxy/proxy2.py
+++ b/seleniumwire/proxy/proxy2.py
@@ -207,7 +207,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
     def _handle_websocket(self, server_sock, response):
         self.connection.settimeout(None)
         server_sock.settimeout(None)
-
+        print('handling websocket')
         def server_read(messages):
             try:
                 while True:
@@ -215,6 +215,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                     messages.append(serverdata)
                     if not serverdata:
                         break
+                    print('adding ws message')
                     self.connection.sendall(serverdata)
             except socket.error:
                 self.log_message('Ending websocket server connection')

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -100,7 +100,7 @@ class Request:
 class Response:
     """Represents an HTTP response."""
 
-    def __init__(self, *, status_code, reason, headers, body=b''):
+    def __init__(self, *, status_code, reason, headers, body=b'', messages=None):
         """Initialise a new Response object.
 
         Args:
@@ -108,11 +108,13 @@ class Response:
             reason: The reason message (e.g. "OK" or "Not Found").
             headers: The response headers as a dictionary.
             body: The response body as bytes.
+            messages: Websocket messages list
         """
         self.status_code = status_code
         self.reason = reason
         self.headers = CaseInsensitiveDict(headers)
         self.body = body
+        self.messages = messages
 
     @property
     def body(self):

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -81,10 +81,7 @@ class Request:
         Returns: A dictionary.
         """
         d = vars(self)
-        if '_body' in d:
-            d.pop('_body')
-        else:
-            d.pop('body')
+        d.pop('_body', None)
         d['headers'] = dict(d['headers'])
 
         if self.response is not None:
@@ -145,10 +142,7 @@ class Response:
         Returns: A dictionary.
         """
         d = dict(vars(self))
-        if '_body' in d:
-            d.pop('_body')
-        else:
-            d.pop('body')
+        d.pop('_body', None)
         d['headers'] = dict(d['headers'])
 
         return d

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -81,7 +81,10 @@ class Request:
         Returns: A dictionary.
         """
         d = vars(self)
-        d.pop('_body')
+        if '_body' in d:
+            d.pop('_body')
+        else:
+            d.pop('body')
         d['headers'] = dict(d['headers'])
 
         if self.response is not None:

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -142,7 +142,10 @@ class Response:
         Returns: A dictionary.
         """
         d = dict(vars(self))
-        d.pop('_body')
+        if '_body' in d:
+            d.pop('_body')
+        else:
+            d.pop('body')
         d['headers'] = dict(d['headers'])
 
         return d

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -115,6 +115,7 @@ class Response:
         self.headers = CaseInsensitiveDict(headers)
         self.body = body
         self.messages = messages
+        print(self)
 
     @property
     def body(self):
@@ -148,7 +149,7 @@ class Response:
 
     def __repr__(self):
         return 'Response(status_code={status_code!r}, reason={reason!r}, headers={headers!r}, ' \
-               'body={_body!r})'.format(**vars(self))
+               'body={_body!r}, messages={messages!r})'.format(**vars(self))
 
     def __str__(self):
         return '{} {}'.format(self.status_code, self.reason)

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -115,7 +115,7 @@ class Response:
         self.headers = CaseInsensitiveDict(headers)
         self.body = body
         self.messages = messages
-        print(self)
+        print(repr(self))
 
     @property
     def body(self):

--- a/seleniumwire/proxy/request.py
+++ b/seleniumwire/proxy/request.py
@@ -140,7 +140,7 @@ class Response:
 
         Returns: A dictionary.
         """
-        d = vars(self)
+        d = dict(vars(self))
         d.pop('_body')
         d['headers'] = dict(d['headers'])
 

--- a/seleniumwire/proxy/server.py
+++ b/seleniumwire/proxy/server.py
@@ -10,7 +10,7 @@ from urllib.request import _parse_proxy
 
 from . import utils
 from .modifier import RequestModifier
-from .storage import RequestStorage
+from .storage import RequestStorage, InMemoryRequestStorage
 
 
 class BoundedThreadingMixin(ThreadingMixIn):
@@ -48,9 +48,12 @@ class ProxyHTTPServer(BoundedThreadingMixin, HTTPServer):
         self.options = options or {}
 
         # Used to stored captured requests
-        self.storage = RequestStorage(
-            base_dir=self.options.pop('request_storage_base_dir', None)
-        )
+        if self.options.pop('in_memory_mode', None):
+            self.storage = InMemoryRequestStorage()
+        else:
+            self.storage = RequestStorage(
+                base_dir=self.options.pop('request_storage_base_dir', None)
+            )
 
         # Used to modify requests/responses passing through the server
         self.modifier = RequestModifier()

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -318,8 +318,19 @@ class InMemoryRequestStorage(RequestStorage):
 
     def _load_body(self, request_id, name):
         request_dir = self._get_request_dir(request_id)
-        return self.dirname_obj_map[(dirname, name)]
+        return self.dirname_obj_map[(request_dir, name)]
 
+
+    def _load_request(self, request_id):
+        request_dir = self._get_request_dir(request_id)
+        request = self.dirname_obj_map[(request_dir, 'request')]
+        try:
+            response = self.dirname_obj_map[(request_dir, 'response')]
+            request.response = response
+        except KeyError:
+            pass
+
+        return request
 
     def _get_request_dir(self, request_id):
         return 'request-{}'.format(request_id)

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -16,14 +16,6 @@ log = logging.getLogger(__name__)
 REMOVE_DATA_OLDER_THAN_DAYS = 1
 
 
-
-def print_args(fn):
-    def new_fn(*args, **kwargs):
-        print(fn, *args, **kwargs)
-        return fn(*args, **kwargs)
-    return new_fn
-
-
 class RequestStorage:
     """Responsible for saving request and response data that passes through the proxy server,
     and provding an API to retrieve that data.
@@ -57,7 +49,6 @@ class RequestStorage:
         self._index = []
         self._lock = threading.Lock()
 
-    @print_args
     def save_request(self, request):
         """Saves the request to storage.
 
@@ -93,7 +84,6 @@ class RequestStorage:
         with open(os.path.join(request_dir, filename), 'wb') as out:
             pickle.dump(obj, out)
 
-    @print_args
     def save_response(self, request_id, response):
         """Saves the response to storage.
 
@@ -131,7 +121,6 @@ class RequestStorage:
 
         return None
 
-    @print_args
     def load_requests(self):
         """Loads all previously saved requests known to the storage (known to its index).
 
@@ -169,7 +158,6 @@ class RequestStorage:
 
         return request
 
-    @print_args
     def load_request_body(self, request_id):
         """Loads the body of the request with the specified id.
 
@@ -182,7 +170,7 @@ class RequestStorage:
             return self._load_body(request_id, 'requestbody')
         except FileNotFoundError:
             return b''
-    @print_args
+
     def load_response_body(self, request_id):
         """Loads the body of the response corresponding to the request with the specified id.
 
@@ -221,7 +209,7 @@ class RequestStorage:
                 # Log a message and return the data untouched
                 log.debug('Unable to decode body: %s', str(e))
         return data
-    @print_args
+
     def load_last_request(self):
         """Loads the last saved request.
 
@@ -236,7 +224,7 @@ class RequestStorage:
                 return None
 
         return self._load_request(last_request.id)
-    @print_args
+
     def clear_requests(self):
         """Clears all requests currently known to this storage."""
         with self._lock:
@@ -245,7 +233,7 @@ class RequestStorage:
 
         for indexed_request in index:
             shutil.rmtree(self._get_request_dir(indexed_request.id), ignore_errors=True)
-    @print_args
+
     def find(self, path, check_response=True):
         """Find the first request that matches the specified path.
 
@@ -271,7 +259,7 @@ class RequestStorage:
                     return self._load_request(indexed_request.id)
 
         return None
-    @print_args
+
     def get_cert_dir(self):
         """Returns a storage-specific path to a directory where the SSL certificates are stored.
 
@@ -284,7 +272,7 @@ class RequestStorage:
 
     def _get_request_dir(self, request_id):
         return os.path.join(self._storage_dir, 'request-{}'.format(request_id))
-    @print_args
+
     def cleanup(self):
         """Removes all stored requests, the storage directory containing those
         requests, and if that is the only storage directory, also removes the
@@ -323,15 +311,12 @@ class InMemoryRequestStorage(RequestStorage):
         # for everything except certs
         self.dirname_obj_map = {}
 
-
     def _save(self, obj, dirname, filename):
         self.dirname_obj_map[(dirname, filename)] = obj
-
 
     def _load_body(self, request_id, name):
         request_dir = self._get_request_dir(request_id)
         return self.dirname_obj_map[(request_dir, name)]
-
 
     def _load_request(self, request_id):
         request_dir = self._get_request_dir(request_id)
@@ -346,7 +331,6 @@ class InMemoryRequestStorage(RequestStorage):
 
     def _get_request_dir(self, request_id):
         return 'request-{}'.format(request_id)
-
 
     def _get_indexed_request(self, request_id):
         index = self._index[:]

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -330,6 +330,7 @@ class InMemoryRequestStorage(RequestStorage):
         except KeyError:
             pass
 
+        print(request)
         return request
 
     def _get_request_dir(self, request_id):

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -306,7 +306,9 @@ class RequestStorage:
 
 class InMemoryRequestStorage(RequestStorage):
     """RequestStorage with all disk operations swapped out"""
-    def __init__(self):
+    def __init__(self, base_dir=None):
+        super().__init__(*args, **kwargs)
+        # for everything except certs
         self.dirname_obj_map = {}
 
 
@@ -331,6 +333,11 @@ class InMemoryRequestStorage(RequestStorage):
                 return indexed_request
 
         return None
+
+    def cleanup(self):
+        self.dirname_obj_map = {}
+        # cleanup certs
+        super().cleanup(*args, **kwargs)
 
 
 class _IndexedRequest(dict):

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -16,6 +16,14 @@ log = logging.getLogger(__name__)
 REMOVE_DATA_OLDER_THAN_DAYS = 1
 
 
+
+def print_args(fn):
+    def new_fn(*args, **kwargs):
+        print(fn, *args, **kwargs)
+        return fn(*args, **kwargs)
+    return new_fn
+
+
 class RequestStorage:
     """Responsible for saving request and response data that passes through the proxy server,
     and provding an API to retrieve that data.
@@ -49,6 +57,7 @@ class RequestStorage:
         self._index = []
         self._lock = threading.Lock()
 
+    @print_args
     def save_request(self, request):
         """Saves the request to storage.
 
@@ -84,6 +93,7 @@ class RequestStorage:
         with open(os.path.join(request_dir, filename), 'wb') as out:
             pickle.dump(obj, out)
 
+    @print_args
     def save_response(self, request_id, response):
         """Saves the response to storage.
 
@@ -121,6 +131,7 @@ class RequestStorage:
 
         return None
 
+    @print_args
     def load_requests(self):
         """Loads all previously saved requests known to the storage (known to its index).
 
@@ -158,6 +169,7 @@ class RequestStorage:
 
         return request
 
+    @print_args
     def load_request_body(self, request_id):
         """Loads the body of the request with the specified id.
 
@@ -170,7 +182,7 @@ class RequestStorage:
             return self._load_body(request_id, 'requestbody')
         except FileNotFoundError:
             return b''
-
+    @print_args
     def load_response_body(self, request_id):
         """Loads the body of the response corresponding to the request with the specified id.
 
@@ -209,7 +221,7 @@ class RequestStorage:
                 # Log a message and return the data untouched
                 log.debug('Unable to decode body: %s', str(e))
         return data
-
+    @print_args
     def load_last_request(self):
         """Loads the last saved request.
 
@@ -224,7 +236,7 @@ class RequestStorage:
                 return None
 
         return self._load_request(last_request.id)
-
+    @print_args
     def clear_requests(self):
         """Clears all requests currently known to this storage."""
         with self._lock:
@@ -233,7 +245,7 @@ class RequestStorage:
 
         for indexed_request in index:
             shutil.rmtree(self._get_request_dir(indexed_request.id), ignore_errors=True)
-
+    @print_args
     def find(self, path, check_response=True):
         """Find the first request that matches the specified path.
 
@@ -259,7 +271,7 @@ class RequestStorage:
                     return self._load_request(indexed_request.id)
 
         return None
-
+    @print_args
     def get_cert_dir(self):
         """Returns a storage-specific path to a directory where the SSL certificates are stored.
 
@@ -272,7 +284,7 @@ class RequestStorage:
 
     def _get_request_dir(self, request_id):
         return os.path.join(self._storage_dir, 'request-{}'.format(request_id))
-
+    @print_args
     def cleanup(self):
         """Removes all stored requests, the storage directory containing those
         requests, and if that is the only storage directory, also removes the

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -330,7 +330,6 @@ class InMemoryRequestStorage(RequestStorage):
         except KeyError:
             pass
 
-        print(request)
         return request
 
     def _get_request_dir(self, request_id):

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -307,7 +307,7 @@ class RequestStorage:
 class InMemoryRequestStorage(RequestStorage):
     """RequestStorage with all disk operations swapped out"""
     def __init__(self, base_dir=None):
-        super().__init__(*args, **kwargs)
+        super().__init__(base_dir=none)
         # for everything except certs
         self.dirname_obj_map = {}
 
@@ -337,7 +337,7 @@ class InMemoryRequestStorage(RequestStorage):
     def cleanup(self):
         self.dirname_obj_map = {}
         # cleanup certs
-        super().cleanup(*args, **kwargs)
+        super().cleanup()
 
 
 class _IndexedRequest(dict):

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -307,7 +307,7 @@ class RequestStorage:
 class InMemoryRequestStorage(RequestStorage):
     """RequestStorage with all disk operations swapped out"""
     def __init__(self, base_dir=None):
-        super().__init__(base_dir=none)
+        super().__init__(base_dir=base_dir)
         # for everything except certs
         self.dirname_obj_map = {}
 

--- a/seleniumwire/proxy/storage.py
+++ b/seleniumwire/proxy/storage.py
@@ -304,6 +304,35 @@ class RequestStorage:
                 pass
 
 
+class InMemoryRequestStorage(RequestStorage):
+    """RequestStorage with all disk operations swapped out"""
+    def __init__(self):
+        self.dirname_obj_map = {}
+
+
+    def _save(self, obj, dirname, filename):
+        self.dirname_obj_map[(dirname, filename)] = obj
+
+
+    def _load_body(self, request_id, name):
+        request_dir = self._get_request_dir(request_id)
+        return self.dirname_obj_map[(dirname, name)]
+
+
+    def _get_request_dir(self, request_id):
+        return 'request-{}'.format(request_id)
+
+
+    def _get_indexed_request(self, request_id):
+        index = self._index[:]
+
+        for indexed_request in index:
+            if indexed_request.id == request_id:
+                return indexed_request
+
+        return None
+
+
 class _IndexedRequest(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     setup_requires=[],
     test_suite='nose.collector',
-    tests_require=['nose'],
+    tests_require=['nose', 'pytest'],
     url='https://github.com/wkeeling/selenium-wire',
     version='2.1.0',
     zip_safe=False,

--- a/tests/seleniumwire/proxy/test_request.py
+++ b/tests/seleniumwire/proxy/test_request.py
@@ -163,6 +163,7 @@ class ResponseTest(TestCase):
         self.assertEqual({
             'status_code': 200,
             'reason': 'OK',
+            'messages': None,
             'headers': {
                 'Content-Type': 'application/json',
                 'Content-Length': 120

--- a/tests/seleniumwire/proxy/test_storage.py
+++ b/tests/seleniumwire/proxy/test_storage.py
@@ -7,300 +7,322 @@ from datetime import datetime, timedelta
 from fnmatch import fnmatch
 from io import BytesIO
 from unittest import TestCase
+import pytest
 
 from seleniumwire.proxy.request import Request, Response
-from seleniumwire.proxy.storage import RequestStorage
+from seleniumwire.proxy.storage import RequestStorage, InMemoryRequestStorage
 
 
-class RequestStorageTest(TestCase):
+@pytest.fixture
+def base_dir():
+    base_dir = os.path.join(os.path.dirname(__file__), 'data')
+    yield base_dir
+    shutil.rmtree(os.path.join(base_dir), ignore_errors=True)
 
-    def test_initialise(self):
-        RequestStorage(base_dir=self.base_dir)
-        storage_dir = glob.glob(os.path.join(self.base_dir, '.seleniumwire', 'storage-*'))
+
+def _get_stored_path(base_dir, request_id, filename):
+    return glob.glob(os.path.join(base_dir, '.seleniumwire', 'storage-*',
+                                  'request-{}'.format(request_id), filename))
 
-        self.assertEqual(1, len(storage_dir))
 
-    def test_cleanup_removes_storage(self):
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.cleanup()
-
-        # The 'seleniumwire' parent folder should have been cleaned up
-        # when there is nothing left inside of it.
-        self.assertFalse(os.listdir(self.base_dir))
-
-    def test_cleanup_does_not_remove_parent_folder(self):
-        # There is an existing storage folder
-        os.makedirs(os.path.join(self.base_dir, '.seleniumwire', 'teststorage'))
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.cleanup()
-
-        # The existing storage folder is not cleaned up
-        self.assertEqual(1, len(os.listdir(self.base_dir)))
-        self.assertTrue(os.path.exists(os.path.join(self.base_dir, '.seleniumwire', 'teststorage')))
-
-    def test_initialise_clears_old_folders(self):
-        old_dir = os.path.join(self.base_dir, '.seleniumwire', 'storage-test1')
-        new_dir = os.path.join(self.base_dir, '.seleniumwire', 'storage-test2')
-        os.makedirs(old_dir)
-        os.makedirs(new_dir)
-        two_days_ago = (datetime.now() - timedelta(days=2)).timestamp()
-        os.utime(old_dir, times=(two_days_ago, two_days_ago))
-
-        RequestStorage(base_dir=self.base_dir)
-
-        self.assertFalse(os.path.exists(old_dir))
-        self.assertTrue(os.path.exists(new_dir))
-
-    def test_save_request(self):
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-
-        storage.save_request(request)
-
-        request_file_path = self._get_stored_path(request.id, 'request')
-
-        with open(request_file_path[0], 'rb') as loaded:
-            loaded_request = pickle.load(loaded)
-
-        self.assertEqual(request.id, loaded_request.id)
-        self.assertEqual('http://www.example.com/test/path/', loaded_request.url)
-        self.assertEqual('GET', loaded_request.method)
-        self.assertEqual({
-            'Host': 'www.example.com',
-            'Accept': '*/*'
-        }, loaded_request.headers)
-        self.assertIsNone(loaded_request.response)
-
-    def test_save_request_with_body(self):
-        body = b'test request body'
-        request = self._create_request(body=body)
-        storage = RequestStorage(base_dir=self.base_dir)
-
-        storage.save_request(request)
-
-        request_body_path = self._get_stored_path(request.id, 'requestbody')
-
-        with open(request_body_path[0], 'rb') as loaded:
-            loaded_body = pickle.load(loaded)
-
-        self.assertEqual(body, loaded_body)
-
-    def test_save_response(self):
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response()
-
-        storage.save_response(request.id, response)
-
-        response_file_path = self._get_stored_path(request.id, 'response')
-
-        with open(response_file_path[0], 'rb') as loaded:
-            loaded_response = pickle.load(loaded)
-
-        self.assertEqual(200, loaded_response.status_code)
-        self.assertEqual('OK', loaded_response.reason)
-        self.assertEqual({
-            'Content-Type': 'application/json',
-            'Content-Length': 500
-        }, loaded_response.headers)
-
-    def test_save_response_with_body(self):
-        body = b'some response body'
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response(body=body)
-
-        storage.save_response(request.id, response)
-
-        response_body_path = self._get_stored_path(request.id, 'responsebody')
-
-        with open(response_body_path[0], 'rb') as loaded:
-            loaded_body = pickle.load(loaded)
-
-        self.assertEqual(b'some response body', loaded_body)
-
-    def test_save_response_no_request(self):
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response()
-        storage.clear_requests()
-
-        storage.save_response(request.id, response)
-
-        response_file_path = self._get_stored_path(request.id, 'response')
-
-        self.assertFalse(response_file_path)
-
-    def test_load_requests(self):
-        request_1 = self._create_request()
-        request_2 = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request_1)
-        storage.save_request(request_2)
-
-        requests = storage.load_requests()
-
-        self.assertEqual(2, len(requests))
-        self.assertEqual(request_1.id, requests[0].id)
-        self.assertEqual(request_2.id, requests[1].id)
-        self.assertIsNone(requests[0].response)
-        self.assertIsNone(requests[1].response)
-
-    def test_load_response(self):
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response()
-        storage.save_response(request.id, response)
-
-        requests = storage.load_requests()
-
-        self.assertIsNotNone(requests[0].response)
-
-    def test_load_request_body(self):
-        body = b'test request body'
-        request = self._create_request(body=body)
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-
-        request_body = storage.load_request_body(request.id)
-
-        self.assertEqual(body, request_body)
-
-    def test_load_response_body(self):
-        body = b'test response body'
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        mock_response = self._create_response(body=body)
-        storage.save_response(request.id, mock_response)
-
-        response_body = storage.load_response_body(request.id)
-
-        self.assertEqual(body, response_body)
-
-    def test_load_response_body_encoded(self):
-        body = b'test response body'
-        io = BytesIO()
-        with gzip.GzipFile(fileobj=io, mode='wb') as f:
-            f.write(body)
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response(body=io.getvalue())
-        response.headers['Content-Encoding'] = 'gzip'
-        storage.save_response(request.id, response)
-
-        response_body = storage.load_response_body(request.id)
-
-        self.assertEqual(body, response_body)
-
-    def test_load_response_body_encoded_error(self):
-        body = b'test response body'
-        request = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request)
-        response = self._create_response(body=body)
-        response.headers['Content-Encoding'] = 'gzip'
-        storage.save_response(request.id, response)
-
-        response_body = storage.load_response_body(request.id)
-
-        self.assertEqual(body, response_body)
-
-    def test_load_last_request(self):
-        request_1 = self._create_request()
-        request_2 = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request_1)
-        storage.save_request(request_2)
-
-        last_request = storage.load_last_request()
-
-        self.assertEqual(request_2.id, last_request.id)
-
-    def test_load_last_request_none(self):
-        storage = RequestStorage(base_dir=self.base_dir)
-
-        last_request = storage.load_last_request()
-
-        self.assertIsNone(last_request)
-
-    def test_clear_requests(self):
-        request_1 = self._create_request()
-        request_2 = self._create_request()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request_1)
-        storage.save_request(request_2)
-
-        storage.clear_requests()
-        requests = storage.load_requests()
-
-        self.assertFalse(requests)
-        self.assertFalse(glob.glob(os.path.join(self.base_dir, '.seleniumwire', 'storage-*', '*')))
-
-    def test_get_cert_dir(self):
-        storage = RequestStorage(base_dir=self.base_dir)
-
-        self.assertTrue(fnmatch(storage.get_cert_dir(),
-                                os.path.join(self.base_dir, '.seleniumwire', 'storage-*', 'certs')))
-
-    def test_find(self):
-        request_1 = self._create_request('http://www.example.com/test/path/?foo=bar')
-        request_2 = self._create_request('http://www.stackoverflow.com/other/path/?x=y')
-        mock_response = self._create_response()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request_1)
-        storage.save_response(request_1.id, mock_response)
-        storage.save_request(request_2)
-
-        self.assertEqual(request_1.id, storage.find('/test/path/').id)
-        self.assertEqual(request_1.id, storage.find('/test/path/\?foo=bar').id)
-        self.assertEqual(request_1.id, storage.find('http://www.example.com/test/path/\?foo=bar').id)
-        self.assertEqual(request_1.id, storage.find('http://www.example.com/test/path/').id)
-
-        self.assertIsNone(storage.find('/different/path'))
-        self.assertIsNone(storage.find('/test/path/?x=y'))
-        self.assertIsNone(storage.find('http://www.example.com/different/path/\?foo=bar'))
-        self.assertIsNone(storage.find('http://www.different.com/test/path/\?foo=bar'))
-        self.assertIsNone(storage.find('http://www.example.com/test/path/\?x=y'))
-
-    def test_find_similar_urls(self):
-        request_1 = self._create_request('https://192.168.1.1/redfish/v1')
-        request_2 = self._create_request('https://192.168.1.1/redfish')
-        mock_response = self._create_response()
-        storage = RequestStorage(base_dir=self.base_dir)
-        storage.save_request(request_1)
-        storage.save_response(request_1.id, mock_response)
-        storage.save_request(request_2)
-        storage.save_response(request_2.id, mock_response)
-
-        self.assertEqual(request_1.id, storage.find('.*v1').id)
-        self.assertEqual(request_2.id, storage.find('https://192.168.1.1/redfish$').id)
-
-    def _get_stored_path(self, request_id, filename):
-        return glob.glob(os.path.join(self.base_dir, '.seleniumwire', 'storage-*',
-                                      'request-{}'.format(request_id), filename))
-
-    def _create_request(self, url='http://www.example.com/test/path/', body=None):
-        headers = {
-            'Host': 'www.example.com',
-            'Accept': '*/*'
-        }
-        return Request(method='GET', url=url, headers=headers, body=body)
-
-    def _create_response(self, body=None):
-        headers = {
-            'Content-Type': 'application/json',
-            'Content-Length': 500
-        }
-        return Response(status_code=200, reason='OK', headers=headers, body=body)
-
-    def setUp(self):
-        self.base_dir = os.path.join(os.path.dirname(__file__), 'data')
-
-    def tearDown(self):
-        shutil.rmtree(os.path.join(self.base_dir), ignore_errors=True)
+def _create_request(url='http://www.example.com/test/path/', body=None):
+    headers = {
+        'Host': 'www.example.com',
+        'Accept': '*/*'
+    }
+    return Request(method='GET', url=url, headers=headers, body=body)
+
+
+def _create_response(body=None):
+    headers = {
+        'Content-Type': 'application/json',
+        'Content-Length': 500
+    }
+    return Response(status_code=200, reason='OK', headers=headers, body=body)
+
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_initialise(base_dir, storage_cls):
+    storage_cls(base_dir=base_dir)
+    storage_dir = glob.glob(os.path.join(base_dir, '.seleniumwire', 'storage-*'))
+
+    assert 1 == len(storage_dir)
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_cleanup_removes_storage(base_dir, storage_cls):
+    storage = storage_cls(base_dir=base_dir)
+    storage.cleanup()
+
+    # The 'seleniumwire' parent folder should have been cleaned up
+    # when there is nothing left inside of it.
+    assert not os.listdir(base_dir)
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_cleanup_does_not_remove_parent_folder(base_dir, storage_cls):
+    # There is an existing storage folder
+    os.makedirs(os.path.join(base_dir, '.seleniumwire', 'teststorage'))
+    storage = storage_cls(base_dir=base_dir)
+    storage.cleanup()
+
+    # The existing storage folder is not cleaned up
+    assert 1 == len(os.listdir(base_dir))
+    assert os.path.exists(os.path.join(base_dir, '.seleniumwire', 'teststorage'))
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_initialise_clears_old_folders(base_dir, storage_cls):
+    old_dir = os.path.join(base_dir, '.seleniumwire', 'storage-test1')
+    new_dir = os.path.join(base_dir, '.seleniumwire', 'storage-test2')
+    os.makedirs(old_dir)
+    os.makedirs(new_dir)
+    two_days_ago = (datetime.now() - timedelta(days=2)).timestamp()
+    os.utime(old_dir, times=(two_days_ago, two_days_ago))
+
+    storage_cls(base_dir=base_dir)
+
+    assert not os.path.exists(old_dir)
+    assert os.path.exists(new_dir)
+
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_requests(base_dir, storage_cls):
+    request_1 = _create_request()
+    request_2 = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request_1)
+    storage.save_request(request_2)
+
+    requests = storage.load_requests()
+
+    assert 2 == len(requests)
+    assert request_1.id == requests[0].id
+    assert request_2.id == requests[1].id
+    assert requests[0].response is None
+    assert requests[1].response is None
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_response(base_dir, storage_cls):
+    request = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response()
+    storage.save_response(request.id, response)
+
+    requests = storage.load_requests()
+
+    assert requests[0].response is not None
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_request_body(base_dir, storage_cls):
+    body = b'test request body'
+    request = _create_request(body=body)
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request)
+
+    request_body = storage.load_request_body(request.id)
+
+    assert body == request_body
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_response_body(base_dir, storage_cls):
+    body = b'test response body'
+    request = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request)
+    mock_response = _create_response(body=body)
+    storage.save_response(request.id, mock_response)
+
+    response_body = storage.load_response_body(request.id)
+
+    assert body == response_body
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_response_body_encoded(base_dir, storage_cls):
+    body = b'test response body'
+    io = BytesIO()
+    with gzip.GzipFile(fileobj=io, mode='wb') as f:
+        f.write(body)
+    request = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response(body=io.getvalue())
+    response.headers['Content-Encoding'] = 'gzip'
+    storage.save_response(request.id, response)
+
+    response_body = storage.load_response_body(request.id)
+
+    assert body == response_body
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_response_body_encoded_error(base_dir, storage_cls):
+    body = b'test response body'
+    request = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response(body=body)
+    response.headers['Content-Encoding'] = 'gzip'
+    storage.save_response(request.id, response)
+
+    response_body = storage.load_response_body(request.id)
+
+    assert body == response_body
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_last_request(base_dir, storage_cls):
+    request_1 = _create_request()
+    request_2 = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request_1)
+    storage.save_request(request_2)
+
+    last_request = storage.load_last_request()
+
+    assert request_2.id == last_request.id
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_load_last_request_none(base_dir, storage_cls):
+    storage = storage_cls(base_dir=base_dir)
+
+    last_request = storage.load_last_request()
+
+    assert last_request is None
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_clear_requests(base_dir, storage_cls):
+    request_1 = _create_request()
+    request_2 = _create_request()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request_1)
+    storage.save_request(request_2)
+
+    storage.clear_requests()
+    requests = storage.load_requests()
+
+    assert not requests
+    assert not glob.glob(os.path.join(base_dir, '.seleniumwire', 'storage-*', '*'))
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_get_cert_dir(base_dir, storage_cls):
+    storage = storage_cls(base_dir=base_dir)
+
+    assert fnmatch(storage.get_cert_dir(),
+                   os.path.join(base_dir, '.seleniumwire', 'storage-*', 'certs'))
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_find(base_dir, storage_cls):
+    request_1 = _create_request('http://www.example.com/test/path/?foo=bar')
+    request_2 = _create_request('http://www.stackoverflow.com/other/path/?x=y')
+    mock_response = _create_response()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request_1)
+    storage.save_response(request_1.id, mock_response)
+    storage.save_request(request_2)
+
+    assert request_1.id == storage.find('/test/path/').id
+    assert request_1.id == storage.find('/test/path/\?foo=bar').id
+    assert request_1.id == storage.find('http://www.example.com/test/path/\?foo=bar').id
+    assert request_1.id == storage.find('http://www.example.com/test/path/').id
+
+    assert storage.find('/different/path') is None
+    assert storage.find('/test/path/?x=y') is None
+    assert storage.find('http://www.example.com/different/path/\?foo=bar') is None
+    assert storage.find('http://www.different.com/test/path/\?foo=bar') is None
+    assert storage.find('http://www.example.com/test/path/\?x=y') is None
+
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_find_similar_urls(base_dir, storage_cls):
+    request_1 = _create_request('https://192.168.1.1/redfish/v1')
+    request_2 = _create_request('https://192.168.1.1/redfish')
+    mock_response = _create_response()
+    storage = storage_cls(base_dir=base_dir)
+    storage.save_request(request_1)
+    storage.save_response(request_1.id, mock_response)
+    storage.save_request(request_2)
+    storage.save_response(request_2.id, mock_response)
+
+    assert request_1.id == storage.find('.*v1').id
+    assert request_2.id == storage.find('https://192.168.1.1/redfish$').id
+
+
+# these tests check disk, only apply to RequestStorage:
+def test_save_request(base_dir):
+    request = _create_request()
+    storage = RequestStorage(base_dir=base_dir)
+
+    storage.save_request(request)
+
+    request_file_path = _get_stored_path(base_dir, request.id, 'request')
+
+    with open(request_file_path[0], 'rb') as loaded:
+        loaded_request = pickle.load(loaded)
+
+    assert request.id == loaded_request.id
+    assert 'http://www.example.com/test/path/' == loaded_request.url
+    assert 'GET' == loaded_request.method
+    assert {
+        'Host': 'www.example.com',
+        'Accept': '*/*'
+    } == loaded_request.headers
+    assert loaded_request.response is None
+
+def test_save_request_with_body(base_dir):
+    body = b'test request body'
+    request = _create_request(body=body)
+    storage = RequestStorage(base_dir=base_dir)
+
+    storage.save_request(request)
+
+    request_body_path = _get_stored_path(base_dir, request.id, 'requestbody')
+
+    with open(request_body_path[0], 'rb') as loaded:
+        loaded_body = pickle.load(loaded)
+
+    assert body == loaded_body
+
+def test_save_response(base_dir):
+    request = _create_request()
+    storage = RequestStorage(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response()
+
+    storage.save_response(request.id, response)
+
+    response_file_path = _get_stored_path(base_dir, request.id, 'response')
+
+    with open(response_file_path[0], 'rb') as loaded:
+        loaded_response = pickle.load(loaded)
+
+    assert 200 == loaded_response.status_code
+    assert 'OK' == loaded_response.reason
+    assert {
+        'Content-Type': 'application/json',
+        'Content-Length': 500
+    } == loaded_response.headers
+
+def test_save_response_with_body(base_dir):
+    body = b'some response body'
+    request = _create_request()
+    storage = RequestStorage(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response(body=body)
+
+    storage.save_response(request.id, response)
+
+    response_body_path = _get_stored_path(base_dir, request.id, 'responsebody')
+
+    with open(response_body_path[0], 'rb') as loaded:
+        loaded_body = pickle.load(loaded)
+
+    assert b'some response body' == loaded_body
+
+def test_save_response_no_request(base_dir):
+    request = _create_request()
+    storage = RequestStorage(base_dir=base_dir)
+    storage.save_request(request)
+    response = _create_response()
+    storage.clear_requests()
+
+    storage.save_response(request.id, response)
+
+    response_file_path = _get_stored_path(base_dir, request.id, 'response')
+
+    assert not response_file_path

--- a/tests/seleniumwire/proxy/test_storage.py
+++ b/tests/seleniumwire/proxy/test_storage.py
@@ -242,6 +242,21 @@ def test_find_similar_urls(base_dir, storage_cls):
     assert request_1.id == storage.find('.*v1').id
     assert request_2.id == storage.find('https://192.168.1.1/redfish$').id
 
+@pytest.mark.parametrize("storage_cls", [RequestStorage, InMemoryRequestStorage])
+def test_save_request_load_request_with_body(base_dir, storage_cls):
+    request = _create_request('https://192.168.1.1/redfish/v1', b'mockrequestbody')
+    response = _create_response(b'mockresponsebody')
+
+    storage = storage_cls(base_dir=base_dir)
+
+    storage.save_request(request)
+    storage.save_response(request.id, response)
+
+    requests = storage.load_requests()
+    assert storage.load_request_body(request.id) == b'mockrequestbody'
+    assert storage.load_response_body(request.id) == b'mockresponsebody'
+
+    storage.load_requests()
 
 # these tests check disk, only apply to RequestStorage:
 def test_save_request(base_dir):


### PR DESCRIPTION
Summary: add `Response.messages` list so websocket messages can be part of the Response and updated as they come in.

- add `messages` list attribute to `Response` object
- append each new ws message to `messages` list in `proxy2.py` `_handle_websocket` (separate thread, not breaking)
- implement `InMemoryRequestStorage`, which keeps all objects except certificates in memory. This is necessary to solve the issue described here https://github.com/wkeeling/selenium-wire/issues/140#issuecomment-664074675
  - this comes with the `in_memory_mode` option to activate, which is required for websockets to work
- refactored `test_storage.py` with `pytest.mark.parameterize` so we can run each test case with both `RequestStorage` and `InMemoryRequestStorage` as the designated `storage_cls`

Still TODO:
- document how to enable websockets and `in_memory_mode`
- fix this bug https://github.com/wkeeling/selenium-wire/pull/143#issuecomment-664555087
- fix failing test cases (why doesn't travis install pytest?)