### PR TITLE
Add body override function

### DIFF
--- a/seleniumwire/proxy/client.py
+++ b/seleniumwire/proxy/client.py
@@ -196,6 +196,18 @@ class AdminClient:
         """Gets any previously set param overrides"""
         return self._make_request('GET', '/param_overrides')
 
+    def set_body_overrides(self, bodies):
+        """Set the body overrides."""
+        self._make_request('POST', '/body_overrides', data=bodies)
+
+    def clear_body_overrides(self):
+        """Clears any previously set body overrides."""
+        self._make_request('DELETE', '/body_overrides')
+
+    def get_body_overrides(self):
+        """Gets any previously set body overrides"""
+        return self._make_request('GET', '/body_overrides')
+
     def set_querystring_overrides(self, overrides):
         """Set the querystring overrides."""
         self._make_request('POST', '/querystring_overrides', data={

--- a/seleniumwire/proxy/handler.py
+++ b/seleniumwire/proxy/handler.py
@@ -61,6 +61,11 @@ class AdminMixin:
                 'POST': self._set_querystring_overrides,
                 'DELETE': self._clear_querystring_overrides
             },
+            '/body_overrides': {
+                'GET': self._get_body_overrides,
+                'POST': self._set_body_overrides,
+                'DELETE': self._clear_body_overrides
+            },
             '/rewrite_rules': {
                 'GET': self._get_rewrite_rules,
                 'POST': self._set_rewrite_rules,
@@ -137,6 +142,18 @@ class AdminMixin:
 
     def _get_param_overrides(self, _):
         return self._create_response(json.dumps(self.modifier.params).encode('utf-8'))
+
+    def _get_body_overrides(self, _):
+        return self._create_response(json.dumps(self.modifier.bodies).encode('utf-8'))
+
+    def _set_body_overrides(self, request):
+        bodies = json.loads(request.body.decode('utf-8'))
+        self.modifier.bodies = bodies
+        return self._create_response(json.dumps({'status': 'ok'}).encode('utf-8'))
+
+    def _clear_body_overrides(self, _):
+        del self.modifier.bodies
+        return self._create_response(json.dumps({'status': 'ok'}).encode('utf-8'))
 
     def _set_querystring_overrides(self, request):
         querystring = json.loads(request.body.decode('utf-8'))['overrides']

--- a/seleniumwire/webdriver/request.py
+++ b/seleniumwire/webdriver/request.py
@@ -153,6 +153,22 @@ class InspectRequestsMixin:
 
     @property
     def body_overrides(self):
+        """The body overrides for outgoing browser requests.
+
+        For 'not GET' requests, the parameters are assumed to be encoded in the
+        request body.
+
+        The value of the body can be a string value or list of sublists,
+        with each sublist having two elements - a URL pattern and body string value.
+        The string value will be encoded, then replace whole http body.
+        And body_overrides has higher priority than param_overrides When they conflict.
+        For example:
+            param_overrides = '{"foo":"bar"}'
+            param_overrides = [
+                ('.*somewhere.com.*', '{"foo":"bar"}'),
+                ('*.somewhere-else.com.*', '{"x":"y"}'),
+            ]
+        """
         return self._client.get_body_overrides()
 
     @body_overrides.setter

--- a/seleniumwire/webdriver/request.py
+++ b/seleniumwire/webdriver/request.py
@@ -152,6 +152,18 @@ class InspectRequestsMixin:
         self._client.clear_param_overrides()
 
     @property
+    def body_overrides(self):
+        return self._client.get_body_overrides()
+
+    @body_overrides.setter
+    def body_overrides(self, bodies):
+        self._client.set_body_overrides(bodies)
+
+    @body_overrides.deleter
+    def body_overrides(self):
+        self._client.clear_body_overrides()
+
+    @property
     def querystring_overrides(self):
         """The querystring overrides for outgoing browser requests.
 

--- a/seleniumwire/webdriver/request.py
+++ b/seleniumwire/webdriver/request.py
@@ -159,12 +159,12 @@ class InspectRequestsMixin:
         request body.
 
         The value of the body can be a string value or list of sublists,
-        with each sublist having two elements - a URL pattern and body string value.
+        with each sublist having two elements - a URL pattern and string value.
         The string value will be encoded, then replace whole http body.
         And body_overrides has higher priority than param_overrides When they conflict.
         For example:
-            param_overrides = '{"foo":"bar"}'
-            param_overrides = [
+            body_overrides = '{"foo":"bar"}'
+            body_overrides = [
                 ('.*somewhere.com.*', '{"foo":"bar"}'),
                 ('*.somewhere-else.com.*', '{"x":"y"}'),
             ]

--- a/tests/seleniumwire/proxy/test_client.py
+++ b/tests/seleniumwire/proxy/test_client.py
@@ -400,7 +400,7 @@ class AdminClientIntegrationTest(TestCase):
         )
 
     def setUp(self):
-        options = {'backend': os.environ.get('SW_TEST_BACKEND', 'mitmproxy')}
+        options = {'backend': os.environ.get('SW_TEST_BACKEND', 'default')}
         if self._testMethodName == 'test_disable_encoding':
             options['disable_encoding'] = True
         self.client = AdminClient()

--- a/tests/seleniumwire/proxy/test_handler.py
+++ b/tests/seleniumwire/proxy/test_handler.py
@@ -295,6 +295,53 @@ class AdminMixinTest(TestCase):
             body=b'{"User-Agent": "useragent"}'
         )
 
+    def test_set_body_overrides(self):
+        self.handler.path = 'http://seleniumwire/body_overrides'
+        self.handler.command = 'POST'
+        self.handler.headers = {
+            'Content-Length': 14
+        }
+        self.mock_rfile.read.return_value = b'{"foo": "bar"}'
+
+        self.handler.handle_admin()
+
+        self.mock_rfile.read.assert_called_once_with(14)
+        self.assertEqual(self.mock_modifier.bodies, {'foo': 'bar'})
+        self.assert_response_mocks_called(
+            status=200,
+            headers=[('Content-Type', 'application/json'),
+                     ('Content-Length', '16')],
+            body=b'{"status": "ok"}'
+        )
+
+    def test_delete_body_overrides(self):
+        self.handler.path = 'http://seleniumwire/body_overrides'
+        self.handler.command = 'DELETE'
+        self.mock_modifier.params = {'foo': 'bar'}
+
+        self.handler.handle_admin()
+
+        self.assertFalse(hasattr(self.mock_modifier, 'bodies'))
+        self.assert_response_mocks_called(
+            status=200,
+            headers=[('Content-Type', 'application/json'),
+                     ('Content-Length', '16')],
+            body=b'{"status": "ok"}'
+        )
+
+    def test_get_param_overrides(self):
+        self.handler.path = 'http://seleniumwire/param_overrides'
+        self.mock_modifier.bodies = {'foo': 'bar'}
+
+        self.handler.handle_admin()
+
+        self.assert_response_mocks_called(
+            status=200,
+            headers=[('Content-Type', 'application/json'),
+                     ('Content-Length', '14')],
+            body=b'{"foo": "bar"}'
+        )
+
     def test_set_param_overrides(self):
         self.handler.path = 'http://seleniumwire/param_overrides'
         self.handler.command = 'POST'

--- a/tests/seleniumwire/proxy/test_modifier.py
+++ b/tests/seleniumwire/proxy/test_modifier.py
@@ -446,6 +446,48 @@ class RequestModifierTest(TestCase):
         self.assertEqual(b'foo=bazz', mock_request.body)
         self.assertEqual('8', mock_request.headers['Content-Length'])
 
+    def test_override_bodies_with_multiple_url_matching(self):
+        self.modifier.bodies = [
+            (".*prod1.server.com.*", '{"foo":"baz","spam":"ham"}'),
+            (".*prod2.server.com.*", '{"foo":"baz2","spam":"ham2"}')
+        ]
+
+        # Modify a request that matches the first pattern
+        url = 'https://prod1.server.com/some/path/12345?foo=bar&spam=eggs'
+        mock_request = self._create_mock_request(url, method='POST')
+
+        self.modifier.modify_request(mock_request)
+        self.assertEqual(b'{"foo":"baz","spam":"ham"}', mock_request.body)
+
+        # Modify a request that matches the second pattern
+        url = 'https://prod2.server.com/some/path/12345?foo=bar&spam=eggs'
+        mock_request = self._create_mock_request(url, method='POST')
+
+        self.modifier.modify_request(mock_request)
+
+        self.assertEqual(b'{"foo":"baz2","spam":"ham2"}', mock_request.body)
+
+    def test_override_bodies_with_url_not_matching(self):
+        self.modifier.params = [
+            (".*prod.server.com.*", {'foo': 'baz'})
+        ]
+        mock_request = self._create_mock_request(method='POST')
+
+        self.modifier.modify_request(mock_request)
+
+        self.assertEqual(b'', mock_request.body)
+
+    def test_add_bodies_when_no_body(self):
+        self.modifier.bodies = '{"foo":"bazz"}'
+        mock_request = self._create_mock_request(
+            url='https://prod1.server.com/some/path/12345',
+            method='POST',
+            body=b''
+        )
+        self.modifier.modify_request(mock_request)
+        self.assertEqual(b'{"foo":"bazz"}', mock_request.body)
+        self.assertEqual('14', mock_request.headers['Content-Length'])
+
     def test_filter_out_param_qs(self):
         self.modifier.params = {
             'foo': None


### PR DESCRIPTION
The body overrides for outgoing browser requests.

For 'not GET' requests, the parameters are assumed to be encoded in the request body.

The value of the body can be a string value or list of sublists, with each sublist having two elements - a URL pattern and body string value. The string value will be encoded, then replace whole http body. And body_overrides has higher priority than param_overrides When they conflict.

For example:
    param_overrides = '{"foo":"bar"}'
    param_overrides = [
        ('.*somewhere.com.*', '{"foo":"bar"}'),
        ('*.somewhere-else.com.*', '{"x":"y"}'),
    ]