### PR TITLE
Add Remote class to init

### DIFF
--- a/seleniumwire/webdriver/__init__.py
+++ b/seleniumwire/webdriver/__init__.py
@@ -1,3 +1,3 @@
 from selenium.webdriver import *  # noqa
 
-from .browser import Chrome, Edge, Firefox, Safari  # noqa
+from .browser import Chrome, Edge, Firefox, Safari, Remote  # noqa


### PR DESCRIPTION
This is for the Remote functionality to use the selenium-wire `webdriver.Remote` class, otherwise it defaults to the selenium one.