### PR TITLE
Preserve duplicate response headers (don't fold)

### DIFF
--- a/seleniumwire/handler.py
+++ b/seleniumwire/handler.py
@@ -141,7 +141,7 @@ class InterceptRequestHandler:
         response = Response(
             status_code=flow.response.status_code,
             reason=flow.response.reason,
-            headers=[(k, v) for k, v in flow.response.headers.items()],
+            headers=[(k, v) for k, v in flow.response.headers.items(multi=True)],
             body=flow.response.raw_content
         )
 

--- a/seleniumwire/mitmproxy.py
+++ b/seleniumwire/mitmproxy.py
@@ -149,7 +149,7 @@ class MitmProxyRequestHandler(CaptureMixin):
         response = Response(
             status_code=flow.response.status_code,
             reason=flow.response.reason,
-            headers=[(k, v) for k, v in flow.response.headers.items()],
+            headers=[(k, v) for k, v in flow.response.headers.items(multi=True)],
             body=flow.response.raw_content
         )
 


### PR DESCRIPTION
Fixes #314 