### PR TITLE
Attempt to resolve DNS through proxy for socks5h

### DIFF
--- a/seleniumwire/thirdparty/mitmproxy/connections.py
+++ b/seleniumwire/thirdparty/mitmproxy/connections.py
@@ -314,7 +314,7 @@ class SocksServerConnection(ServerConnection):
     def getaddrinfo(self, host, port, *args, **kwargs):
         if self.socks_config.scheme == "socks5h":
             return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (host, port))]
-        return super().getaddrinfo(*args, **kwargs)
+        return super().getaddrinfo(host, port, *args, **kwargs)
 
     def makesocket(self, family, type, proto):
         try:

--- a/seleniumwire/thirdparty/mitmproxy/net/tcp.py
+++ b/seleniumwire/thirdparty/mitmproxy/net/tcp.py
@@ -411,12 +411,15 @@ class TCPClient(_Connection):
         # some parties (cuckoo sandbox) need to hook this
         return socket.socket(family, type, proto)
 
+    def getaddrinfo(self, *args, **kwargs):
+        return socket.getaddrinfo(*args, **kwargs)
+
     def create_connection(self, timeout=None):
         # Based on the official socket.create_connection implementation of Python 3.6.
         # https://github.com/python/cpython/blob/3cc5817cfaf5663645f4ee447eaed603d2ad290a/Lib/socket.py
 
         err = None
-        for res in socket.getaddrinfo(self.address[0], self.address[1], 0, socket.SOCK_STREAM):
+        for res in self.getaddrinfo(self.address[0], self.address[1], 0, socket.SOCK_STREAM):
             af, socktype, proto, canonname, sa = res
             sock = None
             try:


### PR DESCRIPTION
This resolved #324 and fixes DNS requests not being forwarded to upstream proxies with a `socks5h` proxy.