### PR TITLE
Fix sporadic proxy auth failure when threaded

### DIFF
--- a/seleniumwire/thirdparty/mitmproxy/addons/upstream_auth.py
+++ b/seleniumwire/thirdparty/mitmproxy/addons/upstream_auth.py
@@ -1,76 +1,40 @@
-import re
 import typing
-import base64
-
-from seleniumwire.thirdparty.mitmproxy import exceptions
-from seleniumwire.thirdparty.mitmproxy import ctx
-from seleniumwire.thirdparty.mitmproxy.utils import strutils
-
-
-def parse_upstream_auth(auth):
-    pattern = re.compile(".+:")
-    if pattern.search(auth) is None:
-        raise exceptions.OptionsError(
-            "Invalid upstream auth specification: %s" % auth
-        )
-    return b"Basic" + b" " + base64.b64encode(strutils.always_bytes(auth))
 
 
 class UpstreamAuth:
     """
-        This addon handles authentication to systems upstream from us for the
-        upstream proxy and reverse proxy mode. There are 4 cases:
+    This addon handles authentication to systems upstream from us for the
+    upstream proxy and reverse proxy mode.
 
-        - Upstream proxy CONNECT requests should have authentication added, and
-          subsequent already connected requests should not.
-        - Upstream proxy regular requests
-        - Reverse proxy regular requests (CONNECT is invalid in this mode)
-        - Upstream SOCKS proxy requests (CONNECT is invalid in this mode)
+    NOTE: due to timing issues, upstream authentication has been moved
+    to the HTTPLayer. It seems that when running in a multi-threaded
+    environment, the hooks that apply authentication are not always
+    invoked at the correct moment leading to sporadic proxy authorization
+    failures. The root cause possibly lies in channel messaging but
+    that would need further investigation.
     """
+
     def __init__(self):
         self.auth = None
 
     def load(self, loader):
         loader.add_option(
-            "upstream_auth", typing.Optional[str], None,
+            "upstream_auth",
+            typing.Optional[str],
+            None,
             """
             Add HTTP Basic authentication to upstream proxy and reverse proxy
             requests. Format: username:password.
-            """
+            """,
         )
 
         loader.add_option(
-            "upstream_custom_auth", typing.Optional[str], None,
+            "upstream_custom_auth",
+            typing.Optional[str],
+            None,
             """
             Add custom authentication to upstream proxy requests by supplying
             the full value of the Proxy-Authorization header. 
             Format: <type> <credentials> - e.g. "Bearer mytoken123"
-            """
+            """,
         )
-
-    def configure(self, updated):
-        # FIXME: We're doing this because our proxy core is terminally confused
-        # at the moment. Ideally, we should be able to check if we're in
-        # reverse proxy mode at the HTTP layer, so that scripts can put the
-        # proxy in reverse proxy mode for specific requests.
-        if "upstream_custom_auth" in updated:
-            if ctx.options.upstream_custom_auth is None:
-                self.auth = None
-            elif "socks" not in ctx.options.mode:
-                self.auth = ctx.options.upstream_custom_auth
-        elif "upstream_auth" in updated:
-            if ctx.options.upstream_auth is None:
-                self.auth = None
-            elif "socks" not in ctx.options.mode:
-                self.auth = parse_upstream_auth(ctx.options.upstream_auth)
-
-    def http_connect(self, f):
-        if self.auth and f.mode == "upstream":
-            f.request.headers["Proxy-Authorization"] = self.auth
-
-    def requestheaders(self, f):
-        if self.auth:
-            if f.mode == "upstream" and not f.server_conn.via:
-                f.request.headers["Proxy-Authorization"] = self.auth
-            elif ctx.options.mode.startswith("reverse"):
-                f.request.headers["Proxy-Authorization"] = self.auth

--- a/seleniumwire/thirdparty/mitmproxy/master.py
+++ b/seleniumwire/thirdparty/mitmproxy/master.py
@@ -4,9 +4,16 @@ import sys
 import threading
 import traceback
 
-from seleniumwire.thirdparty.mitmproxy import (addonmanager, command,
-                                               controller, eventsequence, http,
-                                               log, options, websocket)
+from seleniumwire.thirdparty.mitmproxy import (
+    addonmanager,
+    command,
+    controller,
+    eventsequence,
+    http,
+    log,
+    options,
+    websocket,
+)
 from seleniumwire.thirdparty.mitmproxy.coretypes import basethread
 from seleniumwire.thirdparty.mitmproxy.net import server_spec
 
@@ -23,9 +30,7 @@ class ServerThread(basethread.BaseThread):
     def __init__(self, server):
         self.server = server
         address = getattr(self.server, "address", None)
-        super().__init__(
-            "ServerThread ({})".format(repr(address))
-        )
+        super().__init__("ServerThread ({})".format(repr(address)))
 
     def run(self):
         self.server.serve_forever()
@@ -33,8 +38,9 @@ class ServerThread(basethread.BaseThread):
 
 class Master:
     """
-        The master handles mitmproxy's main event loop.
+    The master handles mitmproxy's main event loop.
     """
+
     def __init__(self, event_loop, opts):
         self.should_exit = threading.Event()
         self.channel = controller.Channel(
@@ -103,7 +109,7 @@ class Master:
 
     def shutdown(self):
         """
-            Shut down the mitmproxy. This method is thread-safe.
+        Shut down the mitmproxy. This method is thread-safe.
         """
         if not self.should_exit.is_set():
             self.should_exit.set()

--- a/seleniumwire/thirdparty/mitmproxy/net/server_spec.py
+++ b/seleniumwire/thirdparty/mitmproxy/net/server_spec.py
@@ -22,7 +22,7 @@ server_spec_re = re.compile(
         /?  #  we allow a trailing backslash, but no path
         $
         """,
-    re.VERBOSE
+    re.VERBOSE,
 )
 
 
@@ -56,10 +56,10 @@ def parse(server_spec: str) -> ServerSpec:
     if m.group("port"):
         port = int(m.group("port"))
     else:
-        port = {
-            "http": 80,
-            "https": 443
-        }[scheme]
+        try:
+            port = {"http": 80, "https": 443}[scheme]
+        except KeyError as e:
+            raise ValueError(f"You need to specify a port when using {scheme}") from e
     if not check.is_valid_port(port):
         raise ValueError("Invalid port: {}".format(port))
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'flake8',
             'gunicorn',
             'httpbin',
+            'isort',
             'mitmproxy==6.0.0',  # Needed by the mitmproxy backend and end2end tests
             'pre-commit',
             'pytest',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             'flake8',
             'gunicorn',
             'httpbin',
-            'mitmproxy',  # Needed by the mitmproxy backend and end2end tests
+            'mitmproxy==6.0.0',  # Needed by the mitmproxy backend and end2end tests
             'pre-commit',
             'pytest',
             'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'gunicorn',
             'httpbin',
             'isort',
-            'mitmproxy==6.0.0',  # Needed by the mitmproxy backend and end2end tests
+            'mitmproxy==5.3.0',  # Needed by the mitmproxy backend and end2end tests
             'pre-commit',
             'pytest',
             'pytest-cov',

--- a/tests/end2end/test_end2end.py
+++ b/tests/end2end/test_end2end.py
@@ -485,3 +485,7 @@ def test_disable_capture(driver_path, chrome_options, httpbin):
         driver.get(f'{httpbin}/html')
 
         assert not driver.requests
+
+
+def test_switch_proxy_on_the_fly():
+    pass


### PR DESCRIPTION
It seems when running in multiple threads, timing issues start to appear in mitmproxy's channel mechanism. This mechanism is used by mitmproxy to communicate between its server and addons. These timing issues mean that event hooks can fire at an incorrect moment, which in the case of the upstream_auth addon means that the `Proxy-Authorization` header is sometimes not applied when it is required, leading to a proxy authorization failure.

This PR moves the code that applies the authorization header from the addon to the server itself, ensuring that the header is applied at the correct time.

Affects: 
#293  
#340 
#341 