### PR TITLE
Versions fixup

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -43,6 +43,8 @@ jobs:
           - os: macos-latest
             py: 3.9
           - os: ubuntu-latest
+            py: '3.10'
+          - os: ubuntu-latest
             py: 3.9
           - os: ubuntu-latest
             py: 3.8

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Selenium Wire extends `Selenium's <https://www.selenium.dev/documentation/en/>`_
 .. image:: https://codecov.io/gh/wkeeling/selenium-wire/branch/master/graph/badge.svg
         :target: https://codecov.io/gh/wkeeling/selenium-wire
 
-.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9-blue.svg
+.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9%2C%203.10-blue.svg
         :target: https://pypi.python.org/pypi/selenium-wire
 
 .. image:: https://img.shields.io/pypi/v/selenium-wire.svg

--- a/seleniumwire/__init__.py
+++ b/seleniumwire/__init__.py
@@ -3,4 +3,4 @@
 """Top-level package for Selenium Wire."""
 
 __author__ = """Will Keeling"""
-__version__ = '4.6.4'
+__version__ = '4.6.5'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.6.4
+current_version = 4.6.5
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,6 @@ setup(
     test_suite='tests.seleniumwire',
     tests_require=['pytest'],
     url='https://github.com/wkeeling/selenium-wire',
-    version='4.6.4',
+    version='4.6.5',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     description="Extends Selenium to give you the ability to inspect requests made by the browser.",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'pyparsing>=2.4.2',
         'pysocks>=1.7.1',
         'selenium>=3.4.0',
-        'werkzeug==2.0.3',
         'wsproto>=0.14',
         'zstandard>=0.14.1',
     ],

--- a/tests/end2end/test_end2end.py
+++ b/tests/end2end/test_end2end.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 
 import seleniumwire
 from seleniumwire import webdriver
@@ -263,7 +264,7 @@ def test_update_json_post_request(driver_path, chrome_options, httpbin):
 
         form = Path(__file__).parent / 'jsonform.html'
         driver.get(f'file:///{str(form)}')
-        button = driver.find_element_by_id('submit')
+        button = driver.find_element(By.ID, 'submit')
         button.click()  # Makes Ajax request so need to wait for it
         request = driver.wait_for_request('/post')
 


### PR DESCRIPTION
This PR removes `werkzeug` from runtime requirements. It was pinned to overcome `httpbin` incompatibility, neither `werkzeug` nor `httpbin` is employed in implementation, they are used in tests only. Otherwise I have dated `werkzeug` version pinned and feel unsafe about this fact.

This was introduced in [recent commit](https://github.com/wkeeling/selenium-wire/commit/824764b052776340e9ac7a703e16fd97c7ea12cc) after [this one](https://github.com/wkeeling/selenium-wire/commit/75821cd9de10b4d17947d722429dc0a22a3a95b8), when dependency was moved to "dev" list but not removed from main list.

Also this adds python3.10 CI job.