### PR TITLE
Limit max version of `pyOpenSSL` to `22.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "hyperframe>=6.0; python_version>='3.6.0'",
         'kaitaistruct>=0.7',
         'pyasn1>=0.3.1',
-        'pyOpenSSL>=19.1.0',
+        'pyOpenSSL>=19.1.0,<=22.0.0',
         'pyparsing>=2.4.2',
         'pysocks>=1.7.1',
         'selenium>=3.4.0',


### PR DESCRIPTION
### What?
Limit max version of `pyOpenSSL` to `22.0.0`

### Why?
Selenium Wire uses a few attributes from `pyOpenSSL` that do not exist anymore in the latest version (`22.1.0`).

Attributes used in Selenium Wire: https://github.com/wkeeling/selenium-wire/blob/69c276430ca862e8313237a1eb87f0c225f3d65d/seleniumwire/thirdparty/mitmproxy/net/tls.py#L43-L44

As of `22.0.0` the attributes existed in `pyOpenSSL`, Reference: https://github.com/pyca/pyopenssl/blob/22.0.0/src/OpenSSL/SSL.py#L38-L39

As of `22.1.0` the attributes seem to be deprecated in  `pyOpenSSL`, Reference: https://github.com/pyca/pyopenssl/blob/22.1.0/src/OpenSSL/SSL.py