### PR TITLE
Decode response with errors parameter

### DIFF
--- a/seleniumwire/utils.py
+++ b/seleniumwire/utils.py
@@ -184,7 +184,7 @@ def urlsafe_address(address):
     return addr, port
 
 
-def decode(data: bytes, encoding: str) -> bytes:
+def decode(data: bytes, encoding: str, errors='strict') -> bytes:
     """Attempt to decode data based on the supplied encoding.
 
     If decoding fails a ValueError is raised.
@@ -195,4 +195,4 @@ def decode(data: bytes, encoding: str) -> bytes:
     Returns: The decoded data.
     Raises: ValueError if the data could not be decoded.
     """
-    return decoder.decode(data, encoding)
+    return decoder.decode(data, encoding, errors)


### PR DESCRIPTION
Some websites have emoji's and those do not decode properly in python when the website uses PHP.
Passing a default 'strict' to decoder.decode, with the option to override it with 'ignore' or 'replace' will make life a bit more easy.