### PR TITLE
Fix desired capabilities in Undetected Chromedriver for Selenium 4.10

### DIFF
--- a/seleniumwire/undetected_chromedriver/webdriver.py
+++ b/seleniumwire/undetected_chromedriver/webdriver.py
@@ -31,20 +31,20 @@ class Chrome(InspectRequestsMixin, DriverCommonMixin, uc.Chrome):
 
         config = self._setup_backend(seleniumwire_options)
 
+        try:
+            chrome_options = kwargs['options']
+        except KeyError:
+            chrome_options = ChromeOptions()
+
         if seleniumwire_options.get('auto_config', True):
             capabilities = kwargs.get('desired_capabilities')
             if capabilities is None:
                 capabilities = DesiredCapabilities.CHROME
             capabilities = capabilities.copy()
-
             capabilities.update(config)
 
-            kwargs['desired_capabilities'] = capabilities
-
-        try:
-            chrome_options = kwargs['options']
-        except KeyError:
-            chrome_options = ChromeOptions()
+            for key, value in capabilities.items():
+                chrome_options.set_capability(key, value)
 
         log.info('Using undetected_chromedriver')
 


### PR DESCRIPTION
The desired_capabilities keyword has been deprecated for a while in Selenium and was officially removed in Selenium 4.10. Therefore, using the latest version of Undetected Chromedriver would accept the desired_capabilities keyword, but they wouldn't actually be applied to the webdriver.

This PR applies the capabilities in the manner that is described in Selenium's official docs and allows Selenium-wire to work with the latest versions of both Selenium and Undetected Chromedriver.

The desired_capabilities keyword is used in other places, but I was unsure how to change it to make it compatible for the other drivers. If desired, I can rework this PR to fix all of those keywords (and in turn fix #697), but I'm not sure how to get the `options` inside some of the constructors (particularly for Remote).