### PR TITLE
Drop dependency on pkg_resources used by kaitaistruct version checking

### DIFF
--- a/seleniumwire/thirdparty/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
+++ b/seleniumwire/thirdparty/mitmproxy/contrib/kaitaistruct/tls_client_hello.py
@@ -7,10 +7,6 @@ from enum import Enum
 
 from kaitaistruct import BytesIO, KaitaiStream, KaitaiStruct
 from kaitaistruct import __version__ as ks_version
-from pkg_resources import parse_version
-
-if parse_version(ks_version) < parse_version('0.7'):
-    raise Exception("Incompatible Kaitai Struct Python API: 0.7 or later is required, but you have %s" % (ks_version))
 
 
 class TlsClientHello(KaitaiStruct):


### PR DESCRIPTION
Some versions of Python to do not ship with pkg_resources.

Backport of mitmproxy/mitmproxy#5403